### PR TITLE
docs: Fix usage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ gh extension upgrade gh-deflake
 ## Usage
 
 ```sh
-gh dispatch <workflow> [flags]
+gh deflake <pull request> [flags]
 ```


### PR DESCRIPTION
👋 I noticed that the command in the README doesn't match the help output:

```
❯ gh help deflake                                            
A GitHub CLI extension for rerunning flaky CI until it passes.

Usage:
  gh deflake <pull request> [flags]

Flags:
  -h, --help      help for gh
  -v, --version   version for gh
```