### PR TITLE
feat(log): add URL to the logs when the checks are green

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ E.g.
 $ gh deflake https://github.com/myorg/myrepo/pull/42
 INFO[0004] Rerun triggered for actions workflow run https://github.com/myorg/myrepo/actions/runs/1234/job/12345 (123456). 
 INFO[0004] Rerun triggered for actions workflow run https://github.com/myorg/myrepo/actions/runs/5678/job/56789 (5678910). 
-INFO[0010] All check suites are now green.
+INFO[0010] All check suites are now green. https://github.com/myorg/myrepo/pull/42
 ```
 
 ## Installation

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,7 +141,7 @@ var rootCmd = &cobra.Command{
 			}
 
 			if allSuitesGreen {
-				log.Info("All check suites are now green.")
+				log.Infof("All check suites are now green. %s", url)
 				break
 			}
 


### PR DESCRIPTION
This helps reasoning about them when we run them in parallel.

Alternatively, each log could be prefixed with the PR in question, but that's good enough.